### PR TITLE
Decorate server

### DIFF
--- a/example/google.server.js
+++ b/example/google.server.js
@@ -22,13 +22,13 @@ server.route({
   method: 'GET',
   path: '/',
   handler: function(req, reply) {
-    var url = hapi_auth_google.generate_google_oauth2_url(opts);
+    var url = server.generate_google_oauth2_url();
     reply("<a href='" + url +"'>Click to Login!</a>" );
   }
 });
 
 server.start(function(err){ // boots your server
-  assert(!err, "FAILED TO Start Server")
+  assert(!err, "FAILED TO Start Server");
 	console.log('Now Visit: http://localhost:'+server.info.port);
 });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,26 +9,21 @@ var oauth2_client;
  *  @returns {Object} oauth2_client - the Google OAuth2 client
  */
 function create_oauth2_client (options) {
-  if(oauth2_client){
-    return oauth2_client;
-  }
-  else {
+
     oauth2_client = new OAuth2Client(process.env.GOOGLE_CLIENT_ID,
                         process.env.GOOGLE_CLIENT_SECRET,
                         options.REDIRECT_URL);
     return oauth2_client;
-  }
 }
 
 
 /**
  *  getGoogleAuthURL creates a url where the user is sent to authenticate
- *  @param {Object} options - the options passed into the plugin
+ *  no param
  *  @returns {String} url - the url where people visit to authenticate
  */
-function generate_google_oauth2_url (options) {
+function generate_google_oauth2_url () {
 
-  var oauth2_client = create_oauth2_client(options);
   var url = oauth2_client.generateAuthUrl({
     access_type: 'offline', // will return a refresh token
     scope: 'https://www.googleapis.com/auth/plus.profile.emails.read'
@@ -41,8 +36,11 @@ function generate_google_oauth2_url (options) {
 /**
  * this plugin creates a /googleauth where google calls back to
  */
+
 exports.register = function googleauth (server, options, next) {
-  var oauth2_client = create_oauth2_client(options);
+
+  oauth2_client = create_oauth2_client(options);
+  server.decorate('server', 'generate_google_oauth2_url', generate_google_oauth2_url)
   server.route([
     {
       method: 'GET',
@@ -72,5 +70,3 @@ exports.register = function googleauth (server, options, next) {
 exports.register.attributes = {
     pkg: require('../package.json')
 };
-
-module.exports.generate_google_oauth2_url = generate_google_oauth2_url;


### PR DESCRIPTION
see [issue 6](https://github.com/dwyl/hapi-auth-google/issues/6): This PR add the method generate_google_oauth2_url  to the server instead of exporting it from the plugin.
