### PR TITLE
Add configuration with auth property to the redirect route

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,6 +45,7 @@ exports.register = function googleauth (server, options, next) {
     {
       method: 'GET',
       path: OPTIONS.REDIRECT_URL, // must be identical to Authorized redirect URI
+      config: {auth: false},
       handler: function google_oauth_handler (req, reply) {
         var code = req.query.code;
         // console.log(' - - - - - - - - - - - - code:');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-auth-google",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Easily allow people to login to your apps using their Google Account",
   "main": "lib/index.js",
   "directories": {


### PR DESCRIPTION
Define the auth property of the redirect route to false. see [issue 11](https://github.com/dwyl/hapi-auth-google/issues/11)
