### PR TITLE
Adds options for online access and no prompts on future access when logging in via Google

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,11 @@ var opts = {
   handler: require('./google_oauth_handler.js'), // your handler
   access_type: 'online', // options: offline, online
   approval_prompt: 'auto', // options: always, auto
-  scope: 'https://www.googleapis.com/auth/plus.profile.emails.read' // ask for their email address
+  scope: 'https://www.googleapis.com/auth/plus.profile.emails.read', // ask for their email address
+  // can use process.env or if you prefer, define here in options:
+  BASE_URL: process.env.BASE_URL,
+  GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,
+  GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET
 };
 
 server.register([{ register: require('hapi-auth-google'), options:opts }],

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ declaring your desired options:
 var opts = {
   REDIRECT_URL: '/googleauth', // must match google app redirect URI from step 2.8
   handler: require('./google_oauth_handler.js'), // your handler
+  access_type: 'online', // options: offline, online
+  approval_prompt: 'auto', // options: always, auto
   scope: 'https://www.googleapis.com/auth/plus.profile.emails.read' // ask for their email address
 };
 

--- a/example/google.server.js
+++ b/example/google.server.js
@@ -11,6 +11,8 @@ server.connection({
 var opts = {
   REDIRECT_URL: '/googleauth',  // must match google app redirect URI
   handler: require('./google_oauth_handler.js'), // your handler
+  access_type: 'offline', // options: offline, online
+  approval_prompt: 'always', // options: always, auto
   scope: 'https://www.googleapis.com/auth/plus.profile.emails.read' // profile
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,9 +10,9 @@ var oauth2_client;
  *  @returns {Object} oauth2_client - the Google OAuth2 client
  */
 function create_oauth2_client () {
-  var google_client_id = (OPTIONS.google_client_id) ? OPTIONS.google_client_id : process.env.GOOGLE_CLIENT_ID;
-  var google_client_secret = (OPTIONS.google_client_secret) ? OPTIONS.google_client_secret : process.env.GOOGLE_CLIENT_SECRET;
-  var base_url = (OPTIONS.base_url) ? OPTIONS.base_url : process.env.BASE_URL;
+  var google_client_id = (OPTIONS.GOOGLE_CLIENT_ID) ? OPTIONS.GOOGLE_CLIENT_ID : process.env.GOOGLE_CLIENT_ID;
+  var google_client_secret = (OPTIONS.GOOGLE_CLIENT_SECRET) ? OPTIONS.GOOGLE_CLIENT_SECRET : process.env.GOOGLE_CLIENT_SECRET;
+  var base_url = (OPTIONS.BASE_URL) ? OPTIONS.BASE_URL : process.env.BASE_URL;
   oauth2_client = new OAuth2Client(
     google_client_id,
     google_client_secret,

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,10 +10,13 @@ var oauth2_client;
  *  @returns {Object} oauth2_client - the Google OAuth2 client
  */
 function create_oauth2_client () {
+  var google_client_id = (OPTIONS.google_client_id) ? OPTIONS.google_client_id : process.env.GOOGLE_CLIENT_ID;
+  var google_client_secret = (OPTIONS.google_client_secret) ? OPTIONS.google_client_secret : process.env.GOOGLE_CLIENT_SECRET;
+  var base_url = (OPTIONS.base_url) ? OPTIONS.base_url : process.env.BASE_URL;
   oauth2_client = new OAuth2Client(
-    process.env.GOOGLE_CLIENT_ID,
-    process.env.GOOGLE_CLIENT_SECRET,
-    process.env.BASE_URL + OPTIONS.REDIRECT_URL
+    google_client_id,
+    google_client_secret,
+    base_url + OPTIONS.REDIRECT_URL
   );
   return oauth2_client;
 }
@@ -25,9 +28,11 @@ function create_oauth2_client () {
  *  @returns {String} url - the url where people visit to authenticate
  */
 function generate_google_oauth2_url () {
+  var access_type = (OPTIONS.access_type) ? OPTIONS.access_type : 'offline';
+  var approval_prompt = (OPTIONS.approval_prompt) ? OPTIONS.approval_prompt : 'force';
   var url = oauth2_client.generateAuthUrl({
-    access_type: 'offline', // will return a refresh token
-    approval_prompt: 'force', 
+    access_type: access_type, // set to offline to force a refresh token
+    approval_prompt: approval_prompt,
     scope: OPTIONS.scope // can be a space-delimited string or array of scopes
   });
   return url;


### PR DESCRIPTION
Under existing code, you can not set certain options for the oAuth client as they are hard coded in this library. Specifically, access_type = online and approval_prompt = force. This forces the client to accept offline access every time they try to log in via Google (via this library).

The changes allow these settings to be specified in the options.

```js
var opts = {
  REDIRECT_URL: '/googleauth', // must match google app redirect URI from step 2.8
  handler: require('./google_oauth_handler.js'), // your handler
  access_type: 'online', // options: offline, online
  approval_prompt: 'auto', // options: always, auto
  scope: 'https://www.googleapis.com/auth/plus.profile.emails.read' // ask for their email address
};
```

It also allows you to pass the google client IDs via the options, which I think is a more transparent way to do this. You could specify:

```js
var opts = {
  REDIRECT_URL: '/googleauth', // must match google app redirect URI from step 2.8
  google_client_id: process.env.GOOGLE_CLIENT_ID,
  google_client_secret: process.env.GOOGLE_CLIENT_SECRET,
  handler: require('./google_oauth_handler.js'), // your handler
  access_type: 'online', // options: offline, online
  approval_prompt: 'auto', // options: always, auto
  scope: 'https://www.googleapis.com/auth/plus.profile.emails.read' // ask for their email address
};
```