### PR TITLE
Update to allow API Keys via Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ your App(s) using their Google Account makes a lot of sense.
 This plugin lets you easily integrate Google Authentication
 into a Hapi-based Web Application / API.
 
-### Key Advantages
+### Key Advantages of _This_ Plugin:
 
-+ It's _**a lot simpler**_ than "_Passport_" or "_Bell_"; you can read the code in a few minutes: [/lib/index.js](https://github.com/dwyl/hapi-auth-google/blob/master/lib/index.js)
-+ _Uses_ **Google's Official Node.js module** and *nothing else*.
++ _**Much simpler**_ than "_Passport_" or "_Bell_"; you can read the code in a few minutes: [/lib/index.js](https://github.com/dwyl/hapi-auth-google/blob/master/lib/index.js)
++ **_Only_ One Dependency**: **Google's Official Node.js module** (_nothing else_)
 + _Complete_ **[step-by-step instructions](https://github.com/dwyl/hapi-auth-google/blob/master/GOOGLE-APP-STEP-BY-STEP-GUIDE.md), example && tests** to get you _**up and running in 5 mins**_.
 + Always **up-to-date** - we use this plugin in our/client projects
 so we are quick to update it when required.
-+ _**We're here to help**_ if you get stuck! [![Join the chat at https://gitter.im/dwyl/chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/dwyl/chat?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
++ _**We're here to help**_ if you get stuck! [![Get Help!](https://img.shields.io/badge/get-help-brightgreen.svg?style=flat)](https://github.com/dwyl/hapi-auth-google/issues)
 
 
 ![OAuth2 workflow](https://cloud.githubusercontent.com/assets/194400/11186352/34dc4882-8c79-11e5-82ec-cba56deba484.png)
@@ -50,7 +50,7 @@ by visiting the google developer console:
 https://console.developers.google.com
 
 > If you are totally new to using the Google API,
-we created   
+we created
 [***GOOGLE-APP-STEP-BY-STEP-GUIDE***](https://github.com/dwyl/hapi-auth-google/blob/master/GOOGLE-APP-STEP-BY-STEP-GUIDE.md) *just* for you!  
 ( *Note: if you still have any questions*, ***ask***! )
 

--- a/example/google.server.js
+++ b/example/google.server.js
@@ -12,7 +12,7 @@ var opts = {
   REDIRECT_URL: '/googleauth',  // must match google app redirect URI
   handler: require('./google_oauth_handler.js'), // your handler
   access_type: 'offline', // options: offline, online
-  approval_prompt: 'always', // options: always, auto
+  approval_prompt: 'auto', // options: always, auto
   scope: 'https://www.googleapis.com/auth/plus.profile.emails.read' // profile
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-auth-google",
-  "version": "10.0.0",
+  "version": "16.0.0",
   "description": "Easily allow people to login to your apps using their Google Account",
   "main": "lib/index.js",
   "directories": {
@@ -46,6 +46,6 @@
     "tape": "^4.6.0"
   },
   "dependencies": {
-    "googleapis": "^12.2.0"
+    "googleapis": "^16.1.0"
   }
 }


### PR DESCRIPTION
This PR picks up where @ddrager's #35 left off...

+ Firstly we _confirm_ that the Travis-CI is "_happy_" ... see: https://travis-ci.org/dwyl/hapi-auth-google/builds/193864895
+ update `googleapis` (_main dependency_) to latest version fixes #37 
+ swap out gitter badge for "get help" badge see: https://github.com/dwyl/repo-badges/issues/23