### PR TITLE
Update googleapis dependency to 22.2.0 from 16.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "tape": "^4.6.0"
   },
   "dependencies": {
-    "googleapis": "^16.1.0"
+    "googleapis": "^22.2.0"
   }
 }


### PR DESCRIPTION
Googleapis dependency don't really have any changes regarding to the authentication API itself, but will update the dependency badges.

If there is anything else I can do to keep this module up-to-date, I would be glad to help ^_^