### PR TITLE
Update googleapis to 22.2.0 from 16.1.0 #46

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "tape": "^4.6.0"
   },
   "dependencies": {
-    "googleapis": "^16.1.0"
+    "googleapis": "^22.2.0"
   }
 }


### PR DESCRIPTION
That's the right commit :innocent: I can't believe I messed up something so simple! Really sorry for the duplicates! As suggested in #46 , I had to create a new branch here and make a pull request from that branch.

It's mentioned in #43 that the dependency is outdated. This change is used to update the dependency badges. Googleapis has no changes, regarding to authentication since v16.