### PR TITLE
Updated dev dependencies #49

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,16 +34,16 @@
     "node": ">=4.0"
   },
   "devDependencies": {
-    "env2": "^2.1.1",
-    "hapi": "^14.2.0",
-    "istanbul": "^0.4.4",
+    "env2": "^2.2.0",
+    "hapi": "^16.6.2",
+    "istanbul": "^0.4.5",
     "jshint": "^2.9.2",
-    "jsonwebtoken": "^7.1.9",
-    "nock": "^8.0.0",
-    "nodemon": "^1.10.0",
-    "pre-commit": "^1.1.3",
+    "jsonwebtoken": "^8.1.0",
+    "nock": "^9.0.25",
+    "nodemon": "^1.12.1",
+    "pre-commit": "^1.2.2",
     "tap-spec": "^4.1.1",
-    "tape": "^4.6.0"
+    "tape": "^4.8.0"
   },
   "dependencies": {
     "googleapis": "^22.2.0"


### PR DESCRIPTION
Some of the dev dependencies #49 had major updates, but there were no issues with updating them for this plugin. The tests are executing successfully with Node.js `v6.11.x` LTS and `v8.7.x` without any deprecation warnings. I noticed that the build is running node `v4.2.4`.

PS. Hapi is updated to the latest stable version `(v16.x.x)`. Would be curious to test it out with the [latest](https://github.com/hapijs/hapi/issues/3623) any soon.